### PR TITLE
ruby-1.9.3p429

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p392.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.github.com/imeyer/ruby-1.9.3-rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
@@ -17,7 +17,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p392-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p429-1.${DISTRIB}.${ARCH}.rpm
 
 **PROFIT!**
 

--- a/ruby19.spec
+++ b/ruby19.spec
@@ -1,5 +1,5 @@
 %define rubyver         1.9.3
-%define rubyminorver    p392
+%define rubyminorver    p429
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429
+- Update for Ruby 1.9.3-p429 release.
 * Tue Apr 23 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p392
 - Update for Ruby 1.9.3-p392 release.
 * Thu Feb 14 2013 Martin Bokman <martin@bokman.org> - 1.9.3-p385


### PR DESCRIPTION
Bumped to ruby-1.9.3p429.
Tested on CentOS 6.4 + EPEL w/ mock.
Not tested on CentOS 5.x
