### PR TITLE
Bumping patch version referenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
 
 **PROFIT!**
 
+If you are having trouble on the last line because of installed rubies, then run:
+
+`yum remove ruby-* puppet facter`
+
 ### What it does
 
 + Builds

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p429.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.github.com/imeyer/ruby-1.9.3-rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
@@ -17,7 +17,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p429-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p448-1.${DISTRIB}.${ARCH}.rpm
 
 **PROFIT!**
 

--- a/ruby19.spec
+++ b/ruby19.spec
@@ -63,7 +63,7 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
-* Thu Jun 27 2013
+* Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448
 - Update for Ruby 1.9.3-p448 release.
 * Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429
 - Update for Ruby 1.9.3-p429 release.

--- a/ruby19.spec
+++ b/ruby19.spec
@@ -1,5 +1,5 @@
 %define rubyver         1.9.3
-%define rubyminorver    p429
+%define rubyminorver    p448
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Thu Jun 27 2013
+- Update for Ruby 1.9.3-p448 release.
 * Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429
 - Update for Ruby 1.9.3-p429 release.
 * Tue Apr 23 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p392


### PR DESCRIPTION
This is the fix of the MITM attack when using CA-signed certificates with null chars CN fields.
