### PR TITLE
Ruby 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
     rpmbuild -bb ruby20.spec
@@ -35,7 +35,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p598-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p645-1.${DISTRIB}.${ARCH}.rpm
 
 
 #### Ruby 2.1.x
@@ -43,7 +43,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec
     rpmbuild -bb ruby21.spec
@@ -51,7 +51,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.5-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.6-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     cd ~/rpmbuild/SOURCES
     wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz
     cd ~/rpmbuild/SPECS
-    wget https://raw.githubusercontent.com/sashkab/ruby-1.9.3-rpm/master/ruby19.spec
+    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
     ARCH=`uname -m`
     KERNEL_REL=`uname -r`
@@ -29,13 +29,29 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     cd ~/rpmbuild/SOURCES
     wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz
     cd ~/rpmbuild/SPECS
-    wget https://raw.githubusercontent.com/sashkab/ruby-1.9.3-rpm/master/ruby20.spec
+    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
     rpmbuild -bb ruby20.spec
     ARCH=`uname -m`
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
     yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p481-1.${DISTRIB}.${ARCH}.rpm
+
+
+#### Ruby 2.1.2
+
+    yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
+    rpmdev-setuptree
+    cd ~/rpmbuild/SOURCES
+    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz
+    cd ~/rpmbuild/SPECS
+    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec
+    rpmbuild -bb ruby21.spec
+    ARCH=`uname -m`
+    KERNEL_REL=`uname -r`
+    KERNEL_TMP=${KERNEL_REL%.$ARCH}
+    DISTRIB=${KERNEL_TMP##*.}
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.2-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p448.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.github.com/imeyer/ruby-1.9.3-rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
@@ -19,7 +19,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p448-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p484-1.${DISTRIB}.${ARCH}.rpm
 
 
 #### Ruby 2.0.0
@@ -27,7 +27,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.github.com/imeyer/ruby-2.0.0-rpm/master/ruby19.spec
     rpmbuild -bb ruby20.spec
@@ -35,7 +35,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p247-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p353-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**
@@ -68,7 +68,7 @@ If you are having trouble on the last line because of installed rubies, then run
 Tested working (as sane as I could test for) on:
 
 * CentOS 5.x x86_64
-* CentOS 6.3 (Final)
+* CentOS 6.4
 
 ## Personal thoughts
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.6.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec
     rpmbuild -bb ruby21.spec
@@ -51,7 +51,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.6-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.7-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # What is this spec?
 
-This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.3+ on RHEL based systems. I have based it off of the work of [FrameOS](http://www.frameos.org) specs for Ruby 1.9.3 and Ruby Enterprise Edition.
+This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.3+  on RHEL based systems. I have based it off of the work of [FrameOS](http://www.frameos.org) specs for Ruby 1.9.3/2.0.0 and Ruby Enterprise Edition.
 
-### How to install
+## How to install
 
-#### RHEL/CentOS 5/6
+### RHEL/CentOS 5/6
+
+#### Ruby 1.9.3
 
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
@@ -19,6 +21,23 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     DISTRIB=${KERNEL_TMP##*.}
     yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p448-1.${DISTRIB}.${ARCH}.rpm
 
+
+#### Ruby 2.0.0
+
+    yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
+    rpmdev-setuptree
+    cd ~/rpmbuild/SOURCES
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p247.tar.gz
+    cd ~/rpmbuild/SPECS
+    wget https://raw.github.com/imeyer/ruby-2.0.0-rpm/master/ruby19.spec
+    rpmbuild -bb ruby20.spec
+    ARCH=`uname -m`
+    KERNEL_REL=`uname -r`
+    KERNEL_TMP=${KERNEL_REL%.$ARCH}
+    DISTRIB=${KERNEL_TMP##*.}
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p247-1.${DISTRIB}.${ARCH}.rpm
+
+
 **PROFIT!**
 
 If you are having trouble on the last line because of installed rubies, then run:
@@ -31,26 +50,26 @@ If you are having trouble on the last line because of installed rubies, then run
 + Installs
 + Overwrites/upgrades your currently installed ruby package (**DANGEROUS**)
 
-### What it does **not** do
+## What it does **not** do
 
 + Split packages into ruby-libs, ruby-devel, etc (looking for help here)
 + Install alongside Ruby 1.8.x
 
-###
+##
 
 + If you upgrade from an already installed 1.8.x, you will need to re-install all of your gems. If anyone has a decent way to do this programatically, i'll add it to the doc.
 
-### Requirements
+## Requirements
 
 + EPEL Yum repository (for rpmdev-setuptree)
 
-### Distro support
+## Distro support
 
 Tested working (as sane as I could test for) on:
 
 * CentOS 5.x x86_64
 * CentOS 6.3 (Final)
 
-### Personal thoughts
+## Personal thoughts
 
 This is by no means, correct, or sane. Nor does it follow any sort of policy for packaging. I leave that to the people who are most familiar with such things, and will willingly accept patches that add those features.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
@@ -19,7 +19,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p484-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p551-1.${DISTRIB}.${ARCH}.rpm
 
 
 #### Ruby 2.0.0
@@ -27,7 +27,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p598.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
     rpmbuild -bb ruby20.spec
@@ -35,15 +35,15 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p481-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p598-1.${DISTRIB}.${ARCH}.rpm
 
 
-#### Ruby 2.1.2
+#### Ruby 2.1.x
 
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.5.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec
     rpmbuild -bb ruby21.spec
@@ -51,7 +51,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.2-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.5-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**

--- a/README.md
+++ b/README.md
@@ -6,23 +6,6 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
 
 ### RHEL/CentOS 5/6
 
-#### Ruby 1.9.3
-
-```
-yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
-rpmdev-setuptree
-cd ~/rpmbuild/SOURCES
-wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
-cd ~/rpmbuild/SPECS
-wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby19.spec
-rpmbuild -bb ruby19.spec
-ARCH=`uname -m`
-KERNEL_REL=`uname -r`
-KERNEL_TMP=${KERNEL_REL%.$ARCH}
-DISTRIB=${KERNEL_TMP##*.}
-yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p551-1.${DISTRIB}.${ARCH}.rpm
-```
-
 #### Ruby 2.0.0
 
 ```
@@ -54,6 +37,10 @@ KERNEL_TMP=${KERNEL_REL%.$ARCH}
 DISTRIB=${KERNEL_TMP##*.}
 yum install ${HOME}/rpmbuild/RPMS/${ARCH}/ruby-2.1.7-1.${DISTRIB}.${ARCH}.rpm
 ```
+
+#### Ruby 2.2.x
+
+**TODO**
 
 **PROFIT!**
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     cd ~/rpmbuild/SOURCES
     wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p484.tar.gz
     cd ~/rpmbuild/SPECS
-    wget https://raw.github.com/imeyer/ruby-1.9.3-rpm/master/ruby19.spec
+    wget https://raw.githubusercontent.com/sashkab/ruby-1.9.3-rpm/master/ruby19.spec
     rpmbuild -bb ruby19.spec
     ARCH=`uname -m`
     KERNEL_REL=`uname -r`
@@ -29,7 +29,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     cd ~/rpmbuild/SOURCES
     wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz
     cd ~/rpmbuild/SPECS
-    wget https://raw.github.com/imeyer/ruby-2.0.0-rpm/master/ruby19.spec
+    wget https://raw.githubusercontent.com/sashkab/ruby-1.9.3-rpm/master/ruby20.spec
     rpmbuild -bb ruby20.spec
     ARCH=`uname -m`
     KERNEL_REL=`uname -r`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p645.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
     rpmbuild -bb ruby20.spec
@@ -35,7 +35,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p645-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p647-1.${DISTRIB}.${ARCH}.rpm
 
 
 #### Ruby 2.1.x

--- a/README.md
+++ b/README.md
@@ -8,51 +8,52 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
 
 #### Ruby 1.9.3
 
-    yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
-    rpmdev-setuptree
-    cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
-    cd ~/rpmbuild/SPECS
-    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby19.spec
-    rpmbuild -bb ruby19.spec
-    ARCH=`uname -m`
-    KERNEL_REL=`uname -r`
-    KERNEL_TMP=${KERNEL_REL%.$ARCH}
-    DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p551-1.${DISTRIB}.${ARCH}.rpm
-
+```
+yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
+rpmdev-setuptree
+cd ~/rpmbuild/SOURCES
+wget http://ftp.ruby-lang.org/pub/ruby/1.9/ruby-1.9.3-p551.tar.gz
+cd ~/rpmbuild/SPECS
+wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby19.spec
+rpmbuild -bb ruby19.spec
+ARCH=`uname -m`
+KERNEL_REL=`uname -r`
+KERNEL_TMP=${KERNEL_REL%.$ARCH}
+DISTRIB=${KERNEL_TMP##*.}
+yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-1.9.3p551-1.${DISTRIB}.${ARCH}.rpm
+```
 
 #### Ruby 2.0.0
 
-    yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
-    rpmdev-setuptree
-    cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz
-    cd ~/rpmbuild/SPECS
-    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
-    rpmbuild -bb ruby20.spec
-    ARCH=`uname -m`
-    KERNEL_REL=`uname -r`
-    KERNEL_TMP=${KERNEL_REL%.$ARCH}
-    DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p647-1.${DISTRIB}.${ARCH}.rpm
-
+```
+yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
+rpmdev-setuptree
+cd ~/rpmbuild/SOURCES
+wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p647.tar.gz
+cd ~/rpmbuild/SPECS
+wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby20.spec
+rpmbuild -bb ruby20.spec
+ARCH=`uname -m`
+KERNEL_REL=`uname -r`
+KERNEL_TMP=${KERNEL_REL%.$ARCH}
+DISTRIB=${KERNEL_TMP##*.}
+yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p647-1.${DISTRIB}.${ARCH}.rpm
+```
 
 #### Ruby 2.1.x
 
-    yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
-    rpmdev-setuptree
-    cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz
-    cd ~/rpmbuild/SPECS
-    wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec
-    rpmbuild -bb ruby21.spec
-    ARCH=`uname -m`
-    KERNEL_REL=`uname -r`
-    KERNEL_TMP=${KERNEL_REL%.$ARCH}
-    DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.1.7-1.${DISTRIB}.${ARCH}.rpm
-
+```
+yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
+rpmdev-setuptree
+wget http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.7.tar.gz -O ${HOME}/rpmbuild/SOURCES/ruby-2.1.7.tar.gz
+wget https://raw.githubusercontent.com/sashkab/ruby.rpm/master/ruby21.spec -O ${HOME}/rpmbuild/SPECS/ruby21.spec
+rpmbuild -bb ${HOME}/rpmbuild/SPECS/ruby21.spec
+ARCH=`uname -m`
+KERNEL_REL=`uname -r`
+KERNEL_TMP=${KERNEL_REL%.$ARCH}
+DISTRIB=${KERNEL_TMP##*.}
+yum install ${HOME}/rpmbuild/RPMS/${ARCH}/ruby-2.1.7-1.${DISTRIB}.${ARCH}.rpm
+```
 
 **PROFIT!**
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     yum install -y rpm-build rpmdevtools readline-devel ncurses-devel gdbm-devel tcl-devel openssl-devel db4-devel byacc libyaml-devel libffi-devel make
     rpmdev-setuptree
     cd ~/rpmbuild/SOURCES
-    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p353.tar.gz
+    wget http://ftp.ruby-lang.org/pub/ruby/2.0/ruby-2.0.0-p481.tar.gz
     cd ~/rpmbuild/SPECS
     wget https://raw.github.com/imeyer/ruby-2.0.0-rpm/master/ruby19.spec
     rpmbuild -bb ruby20.spec
@@ -35,7 +35,7 @@ This spec is an attempt to push for a stable replacement of Ruby 1.8.x with 1.9.
     KERNEL_REL=`uname -r`
     KERNEL_TMP=${KERNEL_REL%.$ARCH}
     DISTRIB=${KERNEL_TMP##*.}
-    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p353-1.${DISTRIB}.${ARCH}.rpm
+    yum localinstall ~/rpmbuild/RPMS/${ARCH}/ruby-2.0.0p481-1.${DISTRIB}.${ARCH}.rpm
 
 
 **PROFIT!**

--- a/ruby19.spec
+++ b/ruby19.spec
@@ -1,5 +1,5 @@
 %define rubyver         1.9.3
-%define rubyminorver    p484
+%define rubyminorver    p551
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Dec 1 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p551
+- Updated for Ruby 1.9.3-p551
 * Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p484
 - Updated for Ruby 1.9.3-p484
 * Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448

--- a/ruby19.spec
+++ b/ruby19.spec
@@ -1,5 +1,5 @@
 %define rubyver         1.9.3
-%define rubyminorver    p448
+%define rubyminorver    p484
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p484
+- Updated for Ruby 1.9.3-p484
 * Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448
 - Update for Ruby 1.9.3-p448 release.
 * Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,0 +1,83 @@
+%define rubyver         2.0.0
+%define rubyminorver    p247
+
+Name:           ruby
+Version:        %{rubyver}%{rubyminorver}
+Release:        1%{?dist}
+License:        Ruby License/GPL - see COPYING
+URL:            http://www.ruby-lang.org/
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRequires:  readline libyaml libyaml-devel readline-devel ncurses ncurses-devel gdbm gdbm-devel glibc-devel tcl-devel gcc unzip openssl-devel db4-devel byacc make libffi-devel
+Requires:       libyaml
+Source0:        ftp://ftp.ruby-lang.org/pub/ruby/ruby-%{rubyver}-%{rubyminorver}.tar.gz
+Summary:        An interpreter of object-oriented scripting language
+Group:          Development/Languages
+Provides: ruby(abi) = 2.0
+Provides: ruby-irb
+Provides: ruby-rdoc
+Provides: ruby-libs
+Provides: ruby-devel
+Provides: rubygems
+Obsoletes: ruby
+Obsoletes: ruby-libs
+Obsoletes: ruby-irb
+Obsoletes: ruby-rdoc
+Obsoletes: ruby-devel
+Obsoletes: rubygems
+
+%description
+Ruby is the interpreted scripting language for quick and easy
+object-oriented programming.  It has many features to process text
+files and to do system management tasks (as in Perl).  It is simple,
+straight-forward, and extensible.
+
+%prep
+%setup -n ruby-%{rubyver}-%{rubyminorver}
+
+%build
+export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing"
+
+%configure \
+  --enable-shared \
+  --disable-rpath \
+  --includedir=%{_includedir}/ruby \
+  --libdir=%{_libdir}
+
+make %{?_smp_mflags}
+
+%install
+# installing binaries ...
+make install DESTDIR=$RPM_BUILD_ROOT
+
+#we don't want to keep the src directory
+rm -rf $RPM_BUILD_ROOT/usr/src
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-, root, root)
+%{_bindir}
+%{_includedir}
+%{_datadir}
+%{_libdir}
+
+%changelog
+* Fri Aug 23 2013 Aleks Bunin <sbunin@mgail.com> - 2.0.0-p247
+- Update for Ruby 2.0.0-p247
+* Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448
+- Update for Ruby 1.9.3-p448 release.
+* Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429
+- Update for Ruby 1.9.3-p429 release.
+* Tue Apr 23 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p392
+- Update for Ruby 1.9.3-p392 release.
+* Thu Feb 14 2013 Martin Bokman <martin@bokman.org> - 1.9.3-p385
+- Update for Ruby 1.9.3-p385 release.
+* Tue Feb 5 2013 Ian Meyer <ianmmeyer@gmail.com> - 1.9.3-p374
+- Update for Ruby 1.9.3-p327 release.
+* Sun Nov 25 2012 Gareth Jones <me@gazj.co.uk> - 1.9.3-p327
+- Update for Ruby 1.9.3-p327 release.
+* Wed Apr 25 2012 mathew <meta@pobox.com> - 1.9.3-p194-1
+- Update for Ruby 1.9.3-p194 release.
+* Sat Feb 24 2012 Ian Meyer <ianmmeyer@gmail.com> - 1.9.3-p125-1
+- Spec to replace system ruby with 1.9.3-p125

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.0.0
-%define rubyminorver    p353
+%define rubyminorver    p481
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Fri Jun 6 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p481
+- Updated for Ruby 2.0.0-p481
 * Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p353
 - Updated for Ruby 2.0.0-p353
 * Fri Aug 23 2013 Aleks Bunin <sbunin@mgail.com> - 2.0.0-p247

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.0.0
-%define rubyminorver    p645
+%define rubyminorver    p647
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Tue Sep 8 2015 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p647
+- Updated for Ruby 2.0.0-p647
 * Mon Jul 6 2015 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p645
 - Updated for Ruby 2.0.0-p645
 * Mon Dec 1 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p598

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.0.0
-%define rubyminorver    p598
+%define rubyminorver    p645
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Jul 6 2015 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p645
+- Updated for Ruby 2.0.0-p645
 * Mon Dec 1 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p598
 - Updated for Ruby 2.0.0-p598
 * Fri Jun 6 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p481

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.0.0
-%define rubyminorver    p481
+%define rubyminorver    p598
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Dec 1 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p598
+- Updated for Ruby 2.0.0-p598
 * Fri Jun 6 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p481
 - Updated for Ruby 2.0.0-p481
 * Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p353

--- a/ruby20.spec
+++ b/ruby20.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.0.0
-%define rubyminorver    p247
+%define rubyminorver    p353
 
 Name:           ruby
 Version:        %{rubyver}%{rubyminorver}
@@ -63,6 +63,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p353
+- Updated for Ruby 2.0.0-p353
 * Fri Aug 23 2013 Aleks Bunin <sbunin@mgail.com> - 2.0.0-p247
 - Update for Ruby 2.0.0-p247
 * Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448

--- a/ruby21.spec
+++ b/ruby21.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.1
-%define rubyminorver    6
+%define rubyminorver    7
 %define rubyversion     %{rubyver}.%{rubyminorver}
 
 Name:           ruby
@@ -65,6 +65,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Tue Sep 7 2015 Aleks Bunin <github@compuix.com> - 2.1.7
+- Updated for Ruby 2.1.7
 * Mon Jul 6 2015 Aleks Bunin <github@compuix.com> - 2.1.6
 - Updated for Ruby 2.1.6
 * Mon Dec 1 2014 Aleks Bunin <github@compuix.com> - 2.1.5

--- a/ruby21.spec
+++ b/ruby21.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.1
-%define rubyminorver    2
+%define rubyminorver    5
 %define rubyversion     %{rubyver}.%{rubyminorver}
 
 Name:           ruby
@@ -65,6 +65,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Dec 1 2014 Aleks Bunin <github@compuix.com> - 2.1.5
+- Updated for Ruby 2.1.5
 * Mon Jun 23 2014 Aleks Bunin <github@compuix.com> - 2.1.2
 - Updated for Ruby 2.1.2
 * Fri Jun 6 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p481

--- a/ruby21.spec
+++ b/ruby21.spec
@@ -1,0 +1,91 @@
+%define rubyver         2.1
+%define rubyminorver    2
+%define rubyversion     %{rubyver}.%{rubyminorver}
+
+Name:           ruby
+Version:        %{rubyversion}
+Release:        1%{?dist}
+License:        Ruby License/GPL - see COPYING
+URL:            http://www.ruby-lang.org/
+BuildRoot:      %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+BuildRequires:  readline libyaml libyaml-devel readline-devel ncurses ncurses-devel gdbm gdbm-devel glibc-devel tcl-devel gcc unzip openssl-devel db4-devel byacc make libffi-devel unzip
+Requires:       libyaml
+Source0:        ftp://ftp.ruby-lang.org/pub/ruby/%{rubyver}/ruby-%{rubyversion}.tar.gz
+Summary:        An interpreter of object-oriented scripting language
+Group:          Development/Languages
+Provides: ruby(abi) = 2.1
+Provides: ruby-irb
+Provides: ruby-rdoc
+Provides: ruby-libs
+Provides: ruby-devel
+Provides: ruby(rubygems)
+Provides: rubygems
+Obsoletes: ruby
+Obsoletes: ruby-libs
+Obsoletes: ruby-irb
+Obsoletes: ruby-rdoc
+Obsoletes: ruby-devel
+Obsoletes: rubygems
+
+%description
+Ruby is the interpreted scripting language for quick and easy
+object-oriented programming.  It has many features to process text
+files and to do system management tasks (as in Perl).  It is simple,
+straight-forward, and extensible.
+
+%prep
+%setup -n ruby-%{rubyversion}
+
+%build
+export CFLAGS="$RPM_OPT_FLAGS -Wall -fno-strict-aliasing"
+
+%configure \
+  --enable-shared \
+  --disable-rpath \
+  --includedir=%{_includedir}/ruby \
+  --libdir=%{_libdir}
+
+make %{?_smp_mflags}
+
+%install
+# installing binaries ...
+make install DESTDIR=$RPM_BUILD_ROOT
+
+#we don't want to keep the src directory
+rm -rf $RPM_BUILD_ROOT/usr/src
+
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+%files
+%defattr(-, root, root)
+%{_bindir}
+%{_includedir}
+%{_datadir}
+%{_libdir}
+
+%changelog
+* Mon Jun 23 2014 Aleks Bunin <github@compuix.com> - 2.1.2
+- Updated for Ruby 2.1.2
+* Fri Jun 6 2014 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p481
+- Updated for Ruby 2.0.0-p481
+* Mon Nov 25 2013 Aleks Bunin <sbunin@gmail.com> - 2.0.0-p353
+- Updated for Ruby 2.0.0-p353
+* Fri Aug 23 2013 Aleks Bunin <sbunin@mgail.com> - 2.0.0-p247
+- Update for Ruby 2.0.0-p247
+* Thu Jun 27 2013 Henrik <henrik@haf.se> - 1.9.3-p448
+- Update for Ruby 1.9.3-p448 release.
+* Thu May 23 2013 Attila Bogár <attila@fidescreativa.com> - 1.9.3-p429
+- Update for Ruby 1.9.3-p429 release.
+* Tue Apr 23 2013 Aleks Bunin <sbunin@gmail.com> - 1.9.3-p392
+- Update for Ruby 1.9.3-p392 release.
+* Thu Feb 14 2013 Martin Bokman <martin@bokman.org> - 1.9.3-p385
+- Update for Ruby 1.9.3-p385 release.
+* Tue Feb 5 2013 Ian Meyer <ianmmeyer@gmail.com> - 1.9.3-p374
+- Update for Ruby 1.9.3-p327 release.
+* Sun Nov 25 2012 Gareth Jones <me@gazj.co.uk> - 1.9.3-p327
+- Update for Ruby 1.9.3-p327 release.
+* Wed Apr 25 2012 mathew <meta@pobox.com> - 1.9.3-p194-1
+- Update for Ruby 1.9.3-p194 release.
+* Sat Feb 24 2012 Ian Meyer <ianmmeyer@gmail.com> - 1.9.3-p125-1
+- Spec to replace system ruby with 1.9.3-p125

--- a/ruby21.spec
+++ b/ruby21.spec
@@ -1,5 +1,5 @@
 %define rubyver         2.1
-%define rubyminorver    5
+%define rubyminorver    6
 %define rubyversion     %{rubyver}.%{rubyminorver}
 
 Name:           ruby
@@ -65,6 +65,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_libdir}
 
 %changelog
+* Mon Jul 6 2015 Aleks Bunin <github@compuix.com> - 2.1.6
+- Updated for Ruby 2.1.6
 * Mon Dec 1 2014 Aleks Bunin <github@compuix.com> - 2.1.5
 - Updated for Ruby 2.1.5
 * Mon Jun 23 2014 Aleks Bunin <github@compuix.com> - 2.1.2


### PR DESCRIPTION
Because 1.9.3-pxxx and 2.0.0-pxxx co-exist, created ruby20.spec from ruby19.spec and udpated for 2.0.0-p247. Updated readme. 
