### PR TITLE
Satisfy also dep specified as 'ruby(rubygems)'

### DIFF
--- a/ruby19.spec
+++ b/ruby19.spec
@@ -17,6 +17,7 @@ Provides: ruby-irb
 Provides: ruby-rdoc
 Provides: ruby-libs
 Provides: ruby-devel
+Provides: ruby(rubygems)
 Provides: rubygems
 Obsoletes: ruby
 Obsoletes: ruby-libs


### PR DESCRIPTION
Some packages will specify dependence on rubygems as ruby(rubygems). This satisfies that dependence. Fixes for instance installation of rubygem-nokogiri from EPEL6
